### PR TITLE
Add jsx as a applicaiton dependency

### DIFF
--- a/src/lager_logstash_backend.app.src
+++ b/src/lager_logstash_backend.app.src
@@ -5,6 +5,7 @@
   {applications, [
     kernel,
     stdlib,
+    jsx,
     lager
   ]},
   {env, []}


### PR DESCRIPTION
Since lager_logstash_backend depends on jsx to work it should be an applicaiton dependency so tools like relx can resolve this requirement.
